### PR TITLE
remove braces from "with" statement

### DIFF
--- a/roles/rabbitmq_cluster/tasks/join_rmq_cluster.yml
+++ b/roles/rabbitmq_cluster/tasks/join_rmq_cluster.yml
@@ -7,7 +7,7 @@
 - name: Include the tasks 'join_rmq_cluster_web.yml' if the count of web nodes are more than one
   include_tasks: join_rmq_cluster_web.yml
   when:
-    - web_node_count >= 2
+    - web_node_count | int >= 2
     - inventory_hostname not in groups['awx_instance_group_task'] and inventory_hostname != rabbitmq_primary_host
 
 - name: Check whether the agent nodes are clustered already

--- a/roles/rabbitmq_cluster/tasks/join_rmq_cluster.yml
+++ b/roles/rabbitmq_cluster/tasks/join_rmq_cluster.yml
@@ -7,7 +7,7 @@
 - name: Include the tasks 'join_rmq_cluster_web.yml' if the count of web nodes are more than one
   include_tasks: join_rmq_cluster_web.yml
   when:
-    - "{{ web_node_count }} >= 2"
+    - web_node_count >= 2
     - inventory_hostname not in groups['awx_instance_group_task'] and inventory_hostname != rabbitmq_primary_host
 
 - name: Check whether the agent nodes are clustered already


### PR DESCRIPTION
## This PR

Fixes the following issue:

```
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ web_node_count }} >= 2

```